### PR TITLE
remove keydown event to fix codearea

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1267,15 +1267,6 @@
                                     :id |0vnJpxGxwi
                                 :id |J1D4EomdBW
                             :id |MGQZ9QLq1J
-                          |yj $ {} (:type :expr) (:by |BkEynDYgM) (:at 1578502154020)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |BkEynDYgM) (:at 1578502154020) (:text |:on-keydown) (:id |53uDNWGBFP)
-                              |j $ {} (:type :expr) (:by |BkEynDYgM) (:at 1578502154020)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |BkEynDYgM) (:at 1578502154020) (:text |on-keydown) (:id |-y1l8MkZ5U)
-                                  |j $ {} (:type :leaf) (:by |BkEynDYgM) (:at 1578502162564) (:text |text) (:id |4ri3ulU1G)
-                                :id |MNbTQ3GUDN
-                            :id |jjS9HvZrHF
                         :id |8UzGW4adF
                     :id |mcZ-piD1C
                   |D $ {} (:type :leaf) (:by |BkEynDYgM) (:at 1578502181384) (:text |[]) (:id |je5H1EzE)

--- a/src/app/comp/container.cljs
+++ b/src/app/comp/container.cljs
@@ -24,14 +24,6 @@
  (when (= action :mount)
    (if (some? el) (codearea el) (js/console.warn "Unknown target" el))))
 
-(defn on-keydown [text]
-  (fn [e d! m!]
-    (if (and (= 13 (:keycode e))
-             (let [event (:event e)] (or (.-metaKey event) (.-ctrlKey event))))
-      (try
-       (let [data (read-string text)] (d! :data {:data data, :error nil}))
-       (catch js/Error err (d! :data {:data nil, :error (.-message err)}))))))
-
 (defcomp
  comp-input-area
  (text)
@@ -44,8 +36,7 @@
             ui/textarea
             ui/flex
             {:font-family ui/font-code, :font-size 12, :word-break :break-all}),
-    :on-input (fn [e d! m!] (d! :text (:value e))),
-    :on-keydown (on-keydown text)})])
+    :on-input (fn [e d! m!] (d! :text (:value e)))})])
 
 (def display-types
   {:edn "EDN",
@@ -159,3 +150,11 @@
                 :font-size 12})}))
     (comment comp-inspect "state" state nil)
     (when config/dev? (cursor-> :reel comp-reel states reel {})))))
+
+(defn on-keydown [text]
+  (fn [e d! m!]
+    (if (and (= 13 (:keycode e))
+             (let [event (:event e)] (or (.-metaKey event) (.-ctrlKey event))))
+      (try
+       (let [data (read-string text)] (d! :data {:data data, :error nil}))
+       (catch js/Error err (d! :data {:data nil, :error (.-message err)}))))))


### PR DESCRIPTION
Respo bnids event to `onkeydown` and codearea binds event to `onkeydown` as well. They conflicted.